### PR TITLE
opentelemetry-instrumentation-boto3sqs v0.64b0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Package license: Apache-2.0
 
 Summary: Boto3 SQS service tracing for OpenTelemetry
 
+Development: https://github.com/open-telemetry/opentelemetry-python-contrib
+
+Boto3 SQS service tracing for OpenTelemetry
+
 Current build status
 ====================
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,11 +25,12 @@ requirements:
     - pip
     - hatchling
   run:
-    - python >=${{ python_min }}
+    - python >=${{ python_min }},<4.0
     - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation ==${{ version }}
     - opentelemetry-semantic-conventions ==${{ version }}
     - wrapt >=1.0.0,<3.0.0
+    - boto3 >=1.0.0,<2.0.0
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,16 +2,17 @@
 schema_version: 1
 
 context:
-  name: opentelemetry-instrumentation-boto3sqs
-  version: "0.63b1"
+  version: "0.64b0"
 
 package:
-  name: ${{ name|lower }}
+  name: opentelemetry-instrumentation-boto3sqs
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/opentelemetry_instrumentation_boto3sqs-${{ version }}.tar.gz
-  sha256: 76064cc454ea46183dba8479819c69cf7cfb6304575e8ce33a3ee7b9f981feca
+  url: 
+    https://pypi.org/packages/source/o/opentelemetry-instrumentation-boto3sqs/opentelemetry_instrumentation_boto3sqs-${{
+    version }}.tar.gz
+  sha256: 35dbf801f8921c65ce40b917f2e9e32cffd3538c10d9498ad0ee672c5909720f
 
 build:
   number: 0
@@ -21,15 +22,14 @@ build:
 requirements:
   host:
     - python ${{ python_min }}.*
-    - hatchling
     - pip
+    - hatchling
   run:
-    - python >=${{ python_min }},<4.0
+    - python >=${{ python_min }}
     - opentelemetry-api >=1.12,<2.dev0
     - opentelemetry-instrumentation ==${{ version }}
     - opentelemetry-semantic-conventions ==${{ version }}
     - wrapt >=1.0.0,<3.0.0
-    - boto3 >=1.0.0,<2.0.0
 
 tests:
   - python:
@@ -37,13 +37,19 @@ tests:
         - opentelemetry
         - opentelemetry.instrumentation.boto3sqs
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
-  summary: Boto3 SQS service tracing for OpenTelemetry
-  homepage: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto3sqs
+  homepage: 
+    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-boto3sqs
   license: Apache-2.0
   license_file: LICENSE
+  summary: Boto3 SQS service tracing for OpenTelemetry
+  description: |
+    Boto3 SQS service tracing for OpenTelemetry
+  repository: https://github.com/open-telemetry/opentelemetry-python-contrib
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
- opentelemetry-instrumentation-boto3sqs 0.63b1 -> 0.64b0
- recipe refreshed to current CFE local shape; built + tested locally with rattler-build before this PR